### PR TITLE
Removed unnecessary WriteHeader(200 ok) call 

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -51,7 +51,6 @@ func CheckAuth(r *http.Request, w http.ResponseWriter) bool {
 	}
 
 	if username == config.Credentials.Username && password == config.Credentials.Password {
-		w.WriteHeader(http.StatusOK)
 		return true
 	}
 


### PR DESCRIPTION
This caused the service to sometimes respond with a "200 ok" header with an empty content, before return the real content.
https://stackoverflow.com/questions/67140505/http-superfluous-response-writeheader-call

https://cs.opensource.google/go/go/+/refs/tags/go1.17.2:src/net/http/server.go;l=146
"Thus explicit calls to WriteHeader are mainly used to send error codes."
