### PR TITLE
Change env variable from ETCD_CONSTRAINT to K3S_ETCD_CONSTRAINT

### DIFF
--- a/init.go
+++ b/init.go
@@ -96,7 +96,7 @@ func init() {
 	}
 
 	// if the constraint is set, determine which kind of
-	config.ETCDConstraint = util.Getenv("ETCD_CONSTRAINT", "")
+	config.ETCDConstraint = util.Getenv("K3S_ETCD_CONSTRAINT", "")
 	if strings.Contains(config.ETCDConstraint, ":") {
 		constraint := strings.Split(config.ETCDConstraint, ":")
 


### PR DESCRIPTION
To be consistent with the naming of the other variables for contraints