### PR TITLE
FIX: Use correct quotation marks

### DIFF
--- a/docs/examples/generate-certs-2.sh
+++ b/docs/examples/generate-certs-2.sh
@@ -22,7 +22,7 @@ basicConstraints = CA:true
 countryName = DE
 stateOrProvinceName = SH
 localityName = EN
-organizationalUnitName	= IT
+organizationalUnitName = IT
 
 [ v3_req ]
 # Extensions to add to a certificate request
@@ -32,13 +32,13 @@ subjectAltName = @alt_names
 
 [alt_names]
 DNS.1 = ${NAME}
-DNS.2 = *.mini
+DNS.2 = *.${DOMAIN}
 DNS.3 = ${NAME}.${DOMAIN}
 EOF
 
 openssl genrsa 2048 > ca-key.pem
 
-openssl req -sha256 -new -x509 -nodes -days 3600 -key ca-key.pem -out ca-cert.pem -subj '/CN=${NAME}.${DOMAIN}' -config ./config.cnf
+openssl req -sha256 -new -x509 -nodes -days 3600 -key ca-key.pem -out ca-cert.pem -subj "/CN=${NAME}.${DOMAIN}" -config ./config.cnf
 
 
 for HOST in $HOSTS


### PR DESCRIPTION
The `generate-certs-2.sh` script in `docs/examples` used single quotes which caused the _verified by_ section to not expand the variables.

before:
![Screenshot from 2022-11-04 15-37-01](https://user-images.githubusercontent.com/45043614/200001857-176e59d9-b4f7-4a70-a900-9fbf06d039f3.png)

after:
![Screenshot from 2022-11-04 15-34-05](https://user-images.githubusercontent.com/45043614/200001908-afeb45ee-5474-4cb5-8475-cacbef0841a3.png)
