### PR TITLE
Added timezone support

### DIFF
--- a/init.go
+++ b/init.go
@@ -88,6 +88,7 @@ func init() {
 	config.VolumeDriver = util.Getenv("VOLUME_DRIVER", "local")
 	config.VolumeK3SServer = util.Getenv("VOLUME_K3S_SERVER", "/data/k3s/server")
 	config.VolumeDS = util.Getenv("VOLUME_DS", "/data/k3s/datastore")
+	config.TimeZone = util.Getenv("TZ", "Africa/Abidjan") // Africa/Abidjan is the timezone identifier for UTC/GMT i.e. 00:00
 
 	// if agent labels are set, unmarshel it into the Mesos Label format.
 	labels := os.Getenv("K3S_AGENT_LABELS")

--- a/scheduler/agent.go
+++ b/scheduler/agent.go
@@ -130,6 +130,10 @@ func (e *Scheduler) StartK3SAgent(taskID string) {
 			Name:  "REDIS_DB",
 			Value: func() *string { x := strconv.Itoa(e.Config.RedisDB); return &x }(),
 		},
+		{
+			Name:  "TZ",
+			Value: &e.Config.TimeZone,
+		},
 	}
 
 	if e.Config.K3SAgentLabels != nil {

--- a/scheduler/datastore.go
+++ b/scheduler/datastore.go
@@ -151,6 +151,10 @@ func (e *Scheduler) setMySQL(cmd *cfg.Command) {
 				return &x
 			}(),
 		},
+		{
+			Name:  "TZ",
+			Value: &e.Config.TimeZone,
+		},
 	}
 	cmd.Volumes = []mesosproto.Volume{
 		{

--- a/scheduler/server.go
+++ b/scheduler/server.go
@@ -180,6 +180,10 @@ func (e *Scheduler) StartK3SServer(taskID string) {
 			Name:  "MESOS_SANDBOX_VAR",
 			Value: &e.Config.MesosSandboxVar,
 		},
+		{
+			Name:  "TZ",
+			Value: &e.Config.TimeZone,
+		},
 	}
 
 	if e.Config.K3SServerLabels != nil {

--- a/types/types.go
+++ b/types/types.go
@@ -88,6 +88,7 @@ type Config struct {
 	VolumeK3SServer             string
 	VolumeDS                    string
 	Version                     M3SVersion
+	TimeZone                    string
 }
 
 // M3SStatus store the current TaskState of the M3s services


### PR DESCRIPTION
Added Timezone Support to change timezone within the cluster nodes & framework via a environment variable passed to the framework. By default, the environment variable will be set to UTC but can be overridden.